### PR TITLE
legacy: removal of bibupload

### DIFF
--- a/invenio_deposit/restful.py
+++ b/invenio_deposit/restful.py
@@ -29,7 +29,6 @@ from werkzeug.utils import secure_filename
 
 from invenio.ext.restful import error_codes, require_api_auth, \
     require_header, require_oauth_scopes
-from invenio.modules.access.engine import acc_authorize_action
 
 from .models import Deposition, DepositionDoesNotExists, DepositionError, \
     DepositionFile, DepositionNotDeletable, DraftDoesNotExists, \

--- a/invenio_deposit/tasks.py
+++ b/invenio_deposit/tasks.py
@@ -361,8 +361,8 @@ def create_recid():
             raise Exception("No submission information package found.")
 
         if 'recid' not in sip.metadata:
-            from invenio.legacy.bibupload.engine import create_new_record
-            sip.metadata['recid'] = create_new_record()
+            sip.metadata['recid'] = PersistentIdentifier.create(
+                'recid', pid_value=None, pid_provider='invenio')
         d.update()
     return _create_recid
 


### PR DESCRIPTION
* INCOMPATIBLE Removes bibupload module.
  (addresses inveniosoftware/invenio#3233)
  (addresses inveniosoftware/invenio#3470)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>