### PR TITLE
installation: fix invenio_access import

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Invenio module for depositing metadata using workflows.
 - Marco Neumann <marco@crepererum.net>
 - Pedro Gaudêncio <pedro.gaudencio@cern.ch>
 - Pedro Gaudêncio <pmgaudencio@gmail.com>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Sebastian Witowski <sebastian.witowski@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
 - Wojciech Ziolek <wojciech.ziolek@cern.ch>

--- a/invenio_deposit/cache.py
+++ b/invenio_deposit/cache.py
@@ -25,7 +25,7 @@ from .registry import deposit_types
 
 def get_authorized_deposition_types(user_info):
     """Return a list of allowed deposition types for a certain user."""
-    from invenio.modules.access.engine import acc_authorize_action
+    from invenio_access.engine import acc_authorize_action
 
     return {
         key for key in deposit_types.mapping().keys()

--- a/invenio_deposit/restful.py
+++ b/invenio_deposit/restful.py
@@ -29,7 +29,7 @@ from werkzeug.utils import secure_filename
 
 from invenio.ext.restful import error_codes, require_api_auth, \
     require_header, require_oauth_scopes
-
+from invenio_access.engine import acc_authorize_action
 from .models import Deposition, DepositionDoesNotExists, DepositionError, \
     DepositionFile, DepositionNotDeletable, DraftDoesNotExists, \
     FileDoesNotExists, FilenameAlreadyExists, ForbiddenAction, \

--- a/invenio_deposit/tasks.py
+++ b/invenio_deposit/tasks.py
@@ -110,7 +110,7 @@ def authorize_user(action, **params):
     """Check if current user is authorized to perform the action."""
     @wraps(authorize_user)
     def _authorize_user(obj, dummy_eng):
-        from invenio.modules.access.engine import acc_authorize_action
+        from invenio_access.engine import acc_authorize_action
 
         auth, message = acc_authorize_action(
             current_user.get_id(),

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,6 +29,7 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/idutils.git#egg=idutils
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore
 -e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'idutils>=0.1.0',
+    'invenio-access>=0.1.0',
     'invenio-formatter>=0.2.0',
     'invenio-knowledge>=0.1.0',
     'invenio-oauth2server>=0.1.0',
@@ -56,6 +57,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>