### PR TITLE
deposit: optional JSONSchema-based forms

### DIFF
--- a/invenio_deposit/bundles.py
+++ b/invenio_deposit/bundles.py
@@ -24,11 +24,14 @@ from __future__ import unicode_literals
 from invenio.base.bundles import invenio as _i
 from invenio.base.bundles import jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
+from invenio.ext.assets.filter import CSSUrlFixer
 
 js = Bundle(
     "vendors/plupload/js/moxie.js",
     "vendors/plupload/js/plupload.dev.js",
+    "vendors/json-editor/dist/jsoneditor.js",
     "js/deposit/init.js",
+    "js/deposit/jsonwidget.js",
     output="deposit.js",
     filters=RequireJSFilter(exclude=[_j, _i]),
     weight=51,
@@ -37,12 +40,27 @@ js = Bundle(
         "ckeditor": "latest",
         "flight": "latest",
         "eonasdan-bootstrap-datetimepicker": "4.14.30",
+        "base-64": "latest",
+        "json-editor": "latest",
+        "select2": "~3",
+        "utf8": "latest",
     }
 )
 
 styles = Bundle(
     "css/deposit/form.css",
     "vendors/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css",  # noqa
+    Bundle(
+        "less/deposit/jsonwidget.less",
+        Bundle(
+            "vendors/select2/select2.css",
+            "vendors/select2/select2-bootstrap.css",
+            filters=CSSUrlFixer('vendors/select2'),
+            output="select2_fixed.css"
+        ),
+        output='jsondeposit.css',
+        filters="less,cleancss",
+    ),
     output="deposit.css",
     filters="cleancss",
     weight=51

--- a/invenio_deposit/fields/jsonfield.py
+++ b/invenio_deposit/fields/jsonfield.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Special fields for JSON-schema based deposits."""
+
+from invenio.ext.template import render_template_to_string
+
+from invenio_jsonschemas.api import validate_json
+
+import jsonschema
+
+import wtforms.validators
+from wtforms.widgets import HTMLString
+
+from ..field_base import WebDepositField
+
+from ..json_utils import blob2json, json2blob
+
+__all__ = ('JSONField', 'JsonWidget', 'validate_schema')
+
+
+def validate_schema(_form, field):
+    """Check if submitted data is valid according to field schema."""
+    try:
+        # trust the schema stored in the field instead the one stored in the
+        # json itself (`json['$schema']`)
+        validate_json(
+            json=field.data,
+            schema=field.schema,
+            additional_properties=False
+        )
+    except jsonschema.SchemaError as e:
+        raise wtforms.validators.ValidationError(
+            "SchemaError: {}".format(e.message)
+        )
+    except jsonschema.ValidationError as e:
+        raise wtforms.validators.ValidationError(
+            "ValidationError: {}\nData: {}".format(e.message, field.data)
+        )
+
+
+class JSONWidget(object):
+
+    """Widget for auto-generated schema-based forms.
+
+    Should be used with a field that provides a `schema` attribute, which is
+    an URI to a JSON-schema.
+    """
+
+    def __call__(self, field, **kwargs):
+        template = 'deposit/jsonwidget.html'
+        field_id = kwargs.pop('id', field.id)
+
+        return HTMLString(
+            render_template_to_string(
+                template,
+                field=field,
+                field_id=field_id,
+                **kwargs
+            )
+        )
+
+
+class JSONField(WebDepositField):
+
+    """Field that provides an auto-generated form based on a schema."""
+
+    def __init__(self, **kwargs):
+        """Set up new `JSONField`.
+
+        :param schema: URI to JSON-schema
+        """
+        self.schema = kwargs.pop('schema')
+
+        defaults = dict(
+            validators=[validate_schema],
+            widget_classes='form-control',
+            widget=JSONWidget()
+        )
+        defaults.update(kwargs)
+
+        super(JSONField, self).__init__(**defaults)
+
+    def process_formdata(self, valuelist):
+        """Transform frontend JSON-blob into internal JSON object (dict)."""
+        if valuelist:
+            self.blob = valuelist[0]
+        else:
+            self.data = None
+
+    @property
+    def blob(self):
+        """Get JSON data as base64 blob."""
+        return json2blob(self.data)
+
+    @blob.setter
+    def blob(self, b):
+        """Set JSON data from base64 blob."""
+        self.data = blob2json(b)
+        self.data['$schema'] = str(self.schema)

--- a/invenio_deposit/fields/wtformsext.py
+++ b/invenio_deposit/fields/wtformsext.py
@@ -184,7 +184,7 @@ class FormField(WebDepositField, wtforms.FormField):
 
     @property
     def json_data(self):
-        """Json data property."""
+        """JSON data property."""
         return self.form.json_data
 
     @property
@@ -337,7 +337,7 @@ class FieldList(WebDepositField, wtforms.FieldList):
 
     @property
     def json_data(self):
-        """Json data property."""
+        """JSON data property."""
         return [
             f.json_data if getattr(f, 'json_data', None) else f.data
             for f in self.get_entries()

--- a/invenio_deposit/form.py
+++ b/invenio_deposit/form.py
@@ -21,6 +21,9 @@
 
 from wtforms import Field, FieldList, Form, FormField
 
+from wtforms.form import FormMeta
+
+
 CFG_GROUPS_META = {
     'classes': None,
     'indication': None,
@@ -382,3 +385,31 @@ class DataExporter(FormVisitor):
             self._push_stack(fieldlist, [])
             super(DataExporter, self).visit_fieldlist(fieldlist)
             self._pop_stack()
+
+
+class JSONForm(FormMeta):
+
+    """Special form that adds json field based on '_schema' attribute.
+
+    The '_schema' attribute should be a string-like object.
+    """
+
+    def __getattr__(cls, name):
+        """Fake 'json'-attribute."""
+        if name is 'json':
+            if 'json' not in cls.__dict__:
+                # do not import on module level, god knows why
+                from .fields.jsonfield import JSONField
+                json = JSONField(
+                    label='',
+                    schema=getattr(cls, '_schema'),
+                    export_key='_json'
+                )
+                setattr(cls, 'json', json)
+            return cls.__dict__['json']
+        else:
+            return super(JSONForm, cls).__getattribute__(name)
+
+    def __dir__(cls):
+        """Add 'json' entry to `dir(...)`-calls."""
+        return cls.__dict__.keys() + ['json']

--- a/invenio_deposit/json_utils.py
+++ b/invenio_deposit/json_utils.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Different utils for JSON handling."""
+
+import base64
+import json
+
+
+def json2blob(j):
+    """Convert JSON object (dict) into a base64 blob.
+
+    The blob format is the following:
+
+    .. code-block::
+
+        base64 encoded data:
+            UTF8 encoded string:
+                stringified JSON
+    """
+    if j:
+        return base64.b64encode(json.dumps(j).encode('utf8'))
+    else:
+        return ""
+
+
+def blob2json(b):
+    """Convert base64 into a JSON object (dict).
+
+    See :func:`json2blob` for an explanation about the blob format.
+    """
+    s = base64.b64decode(b).decode('utf8').strip()
+    if s:
+        return json.loads(s)
+    else:
+        return None

--- a/invenio_deposit/static/js/deposit/jsonwidget.js
+++ b/invenio_deposit/static/js/deposit/jsonwidget.js
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2015 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+require(['jquery', 'base64', 'utf8', 'select2'], function($, base64, utf8, _select2) {
+  'use strict';
+
+  $(function() {
+    JSONEditor.defaults.options.ajax = true;
+    JSONEditor.defaults.options.disable_collapse = true;
+    JSONEditor.defaults.options.disable_edit_json = true;
+    JSONEditor.defaults.options.disable_properties = true;
+    JSONEditor.defaults.options.iconlib = 'fontawesome4';
+    JSONEditor.defaults.options.no_additional_properties = true;
+    JSONEditor.defaults.options.theme = 'bootstrap3';
+    JSONEditor.defaults.options.remove_empty_properties = true;
+
+    // IE<10 does ont support native base64 methods
+    // on the other hand, base64 does not work with almond.js
+    // => so, no IE<10 with ASSET_DEBUG=True
+    var b64decode = window.atob || base64.decode;
+    var b64encode = window.btoa || base64.encode;
+
+    /* JSON blob:
+     *   // secure string
+     *   base64:
+     *     // 0x00-0xFF string (UTF-8)
+     *     utf-8:
+     *       // browser UTF-16 string, other string, ...
+     *       stringify:
+     *         JSON object
+     */
+    function json2blob(json) {
+        if ($.isEmptyObject(json)) {
+            return '';
+        } else {
+            return base64.encode(utf8.encode(JSON.stringify(json)));
+        }
+    }
+    function blob2json(blob) {
+        var str = utf8.decode(base64.decode(blob)).trim();
+        if (str) {
+            return JSON.parse(str);
+        } else {
+            return {};
+        }
+    }
+
+    $('.jsondeposit').each(function() {
+        var element = this;
+        $.getJSON($(element).data('schema'), function(schema) {
+            var loading = $('.jsondeposit-loading', element)[0];
+            var target = $('.jsondeposit-rendered', element)[0];
+            var editor = new JSONEditor(target, {
+                form_name_root: $(element).data('id'),
+                schema: schema,
+            });
+
+
+            var json = $('.jsondeposit-blob', element)[0];
+            var initial_state = blob2json($(json).text());
+            editor.on('ready', function() {
+                if (!$.isEmptyObject(initial_state)) {
+                    editor.setValue(initial_state);
+                }
+                editor.on('change', function() {
+                    $(json).text(json2blob(editor.getValue()));
+                });
+
+                $(loading).remove();
+            });
+        });
+    });
+  });
+})

--- a/invenio_deposit/static/less/deposit/jsonwidget.less
+++ b/invenio_deposit/static/less/deposit/jsonwidget.less
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2015 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+.jsondeposit .row {
+    margin: 0;
+}
+
+.jsondeposit .select2-container {
+    display: block;
+}
+
+.jsondeposit-blob {
+    display: none;
+}
+
+.jsondeposit-loading {
+    font-weight: 700;
+    text-align: center;
+}

--- a/invenio_deposit/templates/deposit/jsonwidget.html
+++ b/invenio_deposit/templates/deposit/jsonwidget.html
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-#
+{#
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -10,21 +9,15 @@
 #
 # Invenio is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
-
-"""Template classes for standard deposit types."""
-
-from __future__ import absolute_import, print_function
-
-from .jsonrecord import JSONRecordDeposition
-from .simplerecord import SimpleRecordDeposition
-
-__all__ = (
-    'JSONRecordDeposition',
-    'SimpleRecordDeposition',
-)
+#}
+<div class="jsondeposit" data-id="{{ field.id }}" data-schema="{{ field.schema }}">
+  <div class="jsondeposit-loading well well-lg"><i class="fa fa-spinner fa-spin"></i> {{ _('Loading') }}</div>
+  <div id="jsondeposit-{{ field.id }}-rendered" class="jsondeposit-rendered"></div>
+  <textarea id="{{ field.id }}" class="jsondeposit-blob" name="{{ field.id }}">{{ field.blob }}</textarea>
+</div>

--- a/invenio_deposit/types/jsonrecord.py
+++ b/invenio_deposit/types/jsonrecord.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Simple test workflow for JSON-schema based deposits."""
+
+from six import iteritems
+
+from .simplerecord import SimpleRecordDeposition
+
+__all__ = ('JSONRecordDeposition', )
+
+
+class JSONRecordDeposition(SimpleRecordDeposition):
+
+    """Submit a simple JSON record."""
+
+    @classmethod
+    def process_sip_metadata(cls, deposition, metadata):
+        """Map keywords to match jsonalchemy configuration."""
+        if '_json' in metadata:
+            json = metadata.pop('_json')
+
+            json['$schema'] = json['$schema'].replace(
+                '/forms',
+                '/records'
+            )
+
+            for k, v in iteritems(json):
+                # FIXME what to do with conflicts?
+                metadata[k] = v

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,15 +21,10 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/idutils.git#egg=idutils
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-jsonschemas.git#egg=invenio-jsonschemas
 -e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore
 -e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,20 @@ test_requirements = [
     'coverage>=3.7.1',
 ]
 
+extras_require = {
+    'docs': [
+        'Sphinx>=1.3',
+        'sphinx_rtd_theme>=0.1.7'
+    ],
+    'jsonschema': [
+        'invenio-jsonschemas>=0.0.0',
+        'jsonschema>=2.5.0',
+    ],
+    'tests': test_requirements
+}
+
+extras_require['tests'] += extras_require['jsonschema']
+
 
 class PyTest(TestCommand):
 
@@ -113,13 +127,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=requirements,
-    extras_require={
-        'docs': [
-            'Sphinx>=1.3',
-            'sphinx_rtd_theme>=0.1.7'
-        ],
-        'tests': test_requirements
-    },
+    extras_require=extras_require,
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import print_function, unicode_literals
+
+from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+
+
+class UtilsTest(InvenioTestCase):
+    def test_blob(self):
+        from invenio_deposit.json_utils import blob2json, json2blob
+
+        json = {
+            'key 01': 1,
+            'key 02': True,
+            'key 03': 1.0,
+            'key 04': 'foo',
+            'key 05': None,
+            'key 06': [1, 2, 3],
+            'key 07': {
+                'foo': 'bar'
+            },
+            'key unicode 👍': 'I enjoyed staying -- באמת! -- at his house.'
+        }
+
+        blob = json2blob(json)
+        self.assertDictEqual(
+            json,
+            blob2json(blob),
+            'incorrect full serializaion + deserialization'
+        )
+
+
+TEST_SUITE = make_test_suite(UtilsTest)
+
+if __name__ == '__main__':
+    run_test_suite(TEST_SUITE)

--- a/tests/test_type_simplerecord.py
+++ b/tests/test_type_simplerecord.py
@@ -36,6 +36,8 @@ class SimpleRecordTest(DepositionTestCase):
 
     """Simple record test."""
 
+    render_templates = False
+
     def setUp(self):
         """Setup."""
         try:
@@ -100,12 +102,14 @@ class SimpleRecordTest(DepositionTestCase):
                                        follow_redirects=True,
                                        base_url=cfg['CFG_SITE_SECURE_URL']))
 
-        self.login("admin", "")
+        self.login('admin', '')
 
         res = self.client.get(url_for('webdeposit.index'))
         self.assert200(res)
-        assert "Tests" in res.data
-        assert "Simple Test" in res.data
+        deposition_types = self.get_context_variable('deposition_types')
+        assert 'simple' in deposition_types
+        assert 'Tests' == deposition_types['simple'].group
+        assert 'Simple Test' == deposition_types['simple'].name
 
         self.assert200(self.client.get(url_for(
             'webdeposit.deposition_type_index', deposition_type='simple'


### PR DESCRIPTION
* NEW Implements optional JSONSchema-based deposit forms. One can
  install required dependencies using 'invenio_deposit[jsonschema]'.

* Improves code style.

Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>
Signed-off-by: Marco Neumann <marco@crepererum.net>

--
closes #6