### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_deposit/bundles.py
+++ b/invenio_deposit/bundles.py
@@ -21,8 +21,8 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _i
-from invenio.base.bundles import jquery as _j
+from invenio_base.bundles import invenio as _i
+from invenio_base.bundles import jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
 from invenio.ext.assets.filter import CSSUrlFixer
 

--- a/invenio_deposit/models.py
+++ b/invenio_deposit/models.py
@@ -37,7 +37,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.datastructures import MultiDict
 from werkzeug.utils import secure_filename
 
-from invenio.base.helpers import unicodifier
+from invenio_base.helpers import unicodifier
 from invenio.ext.restful import UTCISODateTime
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager

--- a/invenio_deposit/storage.py
+++ b/invenio_deposit/storage.py
@@ -25,7 +25,7 @@ import uuid
 
 from fs import opener, path
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.url import make_user_agent_string
 
 

--- a/invenio_deposit/views/deposit.py
+++ b/invenio_deposit/views/deposit.py
@@ -31,7 +31,7 @@ from flask_menu import register_menu
 from werkzeug.datastructures import MultiDict
 from werkzeug.utils import secure_filename
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.ext.principal import permission_required
 
 from ..acl import usedeposit

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,6 +24,7 @@
 
 -e git+git://github.com/inveniosoftware/idutils.git#egg=idutils
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-jsonschemas.git#egg=invenio-jsonschemas
 -e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'idutils>=0.1.0',
     'invenio-access>=0.1.0',
+    'invenio-base>=0.2.1',
     'invenio-formatter>=0.2.1',
     'invenio-knowledge>=0.1.0',
     'invenio-oauth2server>=0.1.0',

--- a/tests/test_type_simplerecord.py
+++ b/tests/test_type_simplerecord.py
@@ -25,8 +25,8 @@ from datetime import date
 
 from flask import url_for
 
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.testsuite import make_test_suite, run_test_suite
 
 from helpers import DepositionTestCase


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>