### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Travis-CI configuration."""
+
+import getpass
+
+from invenio_base.config import EXTENSIONS as _EXTENSIONS
+
+CFG_BIBSCHED_PROCESS_USER = getpass.getuser()
+
+DEBUG = False
+SECRET_KEY = 'MY_SECRET'
+
+# Disable all automatic asset building - false is /usr/bin/false.
+ASSETS_AUTO_BUILD = False
+
+PACKAGES = [
+    'invenio_deposit',
+    'invenio_workflows',
+    'invenio_records',
+    'invenio_oauth2server'
+    'invenio_knowledge',
+    'invenio_access',
+    'invenio_pidstore',
+    'invenio_formatter',
+    'invenio_base',
+]
+
+EXTENSIONS = _EXTENSIONS + ['invenio_deposit.url_converters']

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install check-manifest mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel check-manifest"
+  - "travis_retry pip install check-manifest mock twine wheel"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -63,7 +63,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
-  - "check-manifest"
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ before_install:
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
+  - "mkdir -p ${VIRTUAL_ENV}/var/invenio.base-instance/"
+  - "cp .travis.invenio.cfg ${VIRTUAL_ENV}/var/invenio.base-instance/invenio.cfg"
 
 install:
   - "travis_retry pip install -e git+https://github.com/inveniosoftware/invenio#egg=invenio"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include *.py
 include *.rst
 include *.txt
-include .dockerignore .editorconfig
+include .dockerignore .editorconfig .travis.invenio.cfg
 include LICENSE
 include babel.ini
 include pytest.ini

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_deposit --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_deposit --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -30,5 +30,6 @@
 -e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore
 -e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils
 -e git+git://github.com/inveniosoftware/invenio-workflows.git#egg=invenio-workflows

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,11 @@ requirements = [
 test_requirements = [
     'unittest2>=1.1.0',
     'Flask_Testing>=0.4.1',
-    'pytest>=2.7.0',
-    'pytest_cov>=1.8.0,<2.0.0',
+    'pytest>=2.8.0',
+    'pytest_cov>=2.1.0',
     'pytest_pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
+    'invenio-testing>=0.1.1',
 ]
 
 extras_require = {
@@ -101,9 +102,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,7 @@ import os
 
 from flask import url_for
 
-from invenio.testsuite import InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 
 class DepositionTestCase(InvenioTestCase):

--- a/tests/test_deposit_form.py
+++ b/tests/test_deposit_form.py
@@ -21,7 +21,7 @@
 
 import copy
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testing import InvenioTestCase
 
 
 class WebDepositFormTest(InvenioTestCase):
@@ -433,9 +433,3 @@ class WebDepositFormTest(InvenioTestCase):
         # data['formfield'] = "should have been a dict"
         # form = TestForm(formdata=self.multidict(data))
         # self.assertFalse(form.validate())
-
-
-TEST_SUITE = make_test_suite(WebDepositFormTest)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/tests/test_deposit_models.py
+++ b/tests/test_deposit_models.py
@@ -21,7 +21,7 @@
 
 from flask_registry import RegistryError
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testing import InvenioTestCase
 
 
 class DepositionTest(InvenioTestCase):
@@ -70,8 +70,3 @@ class DepositionTest(InvenioTestCase):
         # remove the records
         Deposition.delete(d)
         Deposition.delete(d2)
-
-TEST_SUITE = make_test_suite(DepositionTest)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/tests/test_deposit_validators.py
+++ b/tests/test_deposit_validators.py
@@ -19,7 +19,7 @@
 
 """Unit tests for deposit module validators."""
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testing import InvenioTestCase
 
 from wtforms.validators import StopValidation, ValidationError
 
@@ -89,8 +89,3 @@ class MintedDOIValidatorTest(InvenioTestCase):
         with self.assertRaises(ValidationError):
             validator(form, field2)
 
-
-TEST_SUITE = make_test_suite(MintedDOIValidatorTest)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function, unicode_literals
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testing import InvenioTestCase
 
 
 class UtilsTest(InvenioTestCase):
@@ -45,9 +45,3 @@ class UtilsTest(InvenioTestCase):
             blob2json(blob),
             'incorrect full serializaion + deserialization'
         )
-
-
-TEST_SUITE = make_test_suite(UtilsTest)
-
-if __name__ == '__main__':
-    run_test_suite(TEST_SUITE)

--- a/tests/test_type_simplerecord.py
+++ b/tests/test_type_simplerecord.py
@@ -27,7 +27,6 @@ from flask import url_for
 
 from invenio_base.globals import cfg
 from invenio_base.i18n import _
-from invenio.testsuite import make_test_suite, run_test_suite
 
 from helpers import DepositionTestCase
 
@@ -129,11 +128,3 @@ class SimpleRecordTest(DepositionTestCase):
                     deposition_type='simple', uuid=dep_id),
             follow_redirects=True)
         )
-
-
-TEST_SUITE = make_test_suite(
-    SimpleRecordTest,
-)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>