### PR TITLE
rest: missing import

### DIFF
--- a/invenio_deposit/__init__.py
+++ b/invenio_deposit/__init__.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
-from .ext import InvenioDeposit
+from .ext import InvenioDeposit, InvenioDepositREST
 from .version import __version__
 
-__all__ = ('__version__', 'InvenioDeposit')
+__all__ = ('__version__', 'InvenioDeposit', 'InvenioDepositREST')

--- a/invenio_deposit/config.py
+++ b/invenio_deposit/config.py
@@ -27,6 +27,8 @@
 DEPOSIT_SEARCH_API = '/api/deposits'
 """URL of search endpoint for deposits."""
 
+DEPOSIT_RECORDS_API = '/api/deposits/{pid_value}'
+
 DEPOSIT_PID_MINTER = 'recid'
 
 DEPOSIT_REST_ENDPOINTS = dict(

--- a/invenio_deposit/templates/invenio_deposit/edit.html
+++ b/invenio_deposit/templates/invenio_deposit/edit.html
@@ -44,7 +44,7 @@
       <div class="col-md-12">
         <div id="invenio-records">
           <invenio-records
-            action-endpoint="{{ url_for('invenio_deposit_rest.deposit_item', pid_value=pid.pid_value) }}"
+            action-endpoint="{{ config.DEPOSIT_SEARCH_API }}"
             extra-params="{}"
             form="{{ url_for('static', filename='json/invenio_deposit/form.json') }}"
             record='{{ record | tojson }}'


### PR DESCRIPTION
* Adds InvenioDepistREST as an import to __init__.py

* Replaces an old endpoint in a template with a config key.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>