### PR TITLE
global: rename of `pid_type` to `depid`

### DIFF
--- a/invenio_deposit/config.py
+++ b/invenio_deposit/config.py
@@ -48,11 +48,11 @@ DEPOSIT_DEFAULT_JSONSCHEMA = 'deposits/deposit-v1.0.0.json'
 DEPOSIT_DEFAULT_SCHEMAFORM = 'json/invenio_deposit/form.json'
 """Default Angular Schema Form."""
 
-_PID = 'pid(dep,record_class="invenio_deposit.api:Deposit")'
+_PID = 'pid(depid,record_class="invenio_deposit.api:Deposit")'
 
 DEPOSIT_REST_ENDPOINTS = dict(
-    dep=dict(
-        pid_type='dep',
+    depid=dict(
+        pid_type='depid',
         pid_minter='deposit',
         pid_fetcher='deposit',
         record_class='invenio_deposit.api:Deposit',
@@ -122,8 +122,8 @@ DEPOSIT_REST_FACETS = dict(
 )
 
 DEPOSIT_RECORDS_UI_ENDPOINTS = dict(
-    dep=dict(
-        pid_type='dep',
+    depid=dict(
+        pid_type='depid',
         route='/deposit/<pid_value>',
         template='invenio_deposit/edit.html',
         record_class='invenio_deposit.api:Deposit',

--- a/invenio_deposit/providers.py
+++ b/invenio_deposit/providers.py
@@ -33,7 +33,7 @@ from invenio_pidstore.providers.base import BaseProvider
 class DepositProvider(BaseProvider):
     """Deposit identifier provider."""
 
-    pid_type = 'dep'
+    pid_type = 'depid'
     """Type of persistent identifier."""
 
     pid_provider = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ def app(request):
         OAUTHLIB_INSECURE_TRANSPORT=True,
         OAUTH2_CACHE_TYPE='simple',
     )
+    app_.url_map.converters['pid'] = PIDConverter
     FlaskCLI(app_)
     Babel(app_)
     FlaskCeleryExt(app_)

--- a/tests/test_invenio_deposit.py
+++ b/tests/test_invenio_deposit.py
@@ -28,7 +28,6 @@
 from __future__ import absolute_import, print_function
 
 from flask import Flask
-from flask_babelex import Babel
 from flask_cli import FlaskCLI
 from invenio_records_rest.utils import PIDConverter
 

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -54,7 +54,8 @@ def test_edit_deposit_users(app, db, es, users, location, deposit,
                 # login
                 res = client.post(url_for_security('login'), data=user_info)
             res = client.put(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=json_headers
             )
@@ -70,7 +71,8 @@ def test_edit_deposit_by_good_oauth2_token(app, db, es, users, location,
         # with oauth2
         with app.test_client() as client:
             res = client.put(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=oauth2_headers_user_1
             )
@@ -86,7 +88,8 @@ def test_edit_deposit_by_bad_oauth2_token(app, db, es, users, location,
         # with oauth2
         with app.test_client() as client:
             res = client.put(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=oauth2_headers_user_2
             )
@@ -111,7 +114,8 @@ def test_delete_deposit_users(app, db, es, users, location, deposit,
                 # login
                 res = client.post(url_for_security('login'), data=user_info)
             res = client.delete(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=json_headers
             )
@@ -127,7 +131,8 @@ def test_delete_deposit_by_good_oauth2_token(app, db, es, users, location,
         # with oauth2
         with app.test_client() as client:
             res = client.delete(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=oauth2_headers_user_1
             )
@@ -143,7 +148,8 @@ def test_delete_deposit_by_bad_oauth2_token(app, db, es, users, location,
         # with oauth2
         with app.test_client() as client:
             res = client.delete(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 data=json.dumps({"title": "bar"}),
                 headers=oauth2_headers_user_2
             )
@@ -157,7 +163,7 @@ def test_deposition_file_operations(app, db, es, location, users,
     with app.test_request_context():
         with app.test_client() as client:
             # create deposit
-            res = client.post(url_for('invenio_deposit_rest.dep_list'),
+            res = client.post(url_for('invenio_deposit_rest.depid_list'),
                               data=json.dumps({}),
                               headers=oauth2_headers_user_1)
             assert res.status_code == 201
@@ -168,7 +174,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Upload a file
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit_id),
                 data=pdf_file,
                 content_type='multipart/form-data',
@@ -184,7 +190,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Upload another file
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit_id),
                 data=pdf_file2,
                 content_type='multipart/form-data',
@@ -195,7 +201,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Upload another file with identical name
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit_id),
                 data=pdf_file2_samename,
                 content_type='multipart/form-data',
@@ -205,7 +211,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Get file info
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit_id,
                 key=file_data['filename']),
                 headers=oauth2_headers_user_1
@@ -216,7 +222,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Get non-existing file
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit_id,
                 key='bad-key'),
                 headers=oauth2_headers_user_1
@@ -226,7 +232,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             # Delete non-existing file
             res = client.delete(
                 url_for(
-                    'invenio_deposit_rest.dep_file',
+                    'invenio_deposit_rest.depid_file',
                     pid_value=deposit_id,
                     key='bad-key',
                 ),
@@ -237,7 +243,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             # Get list of files
             res = client.get(
                 url_for(
-                    'invenio_deposit_rest.dep_files',
+                    'invenio_deposit_rest.depid_files',
                     pid_value=deposit_id
                 ),
                 headers=oauth2_headers_user_1
@@ -256,7 +262,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Sort files - invalid query
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit_id),
                 data=json.dumps(invalid_files_list),
                 headers=oauth2_headers_user_1
@@ -265,7 +271,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Sort files - valid query
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit_id),
                 data=json.dumps(id_files_list),
                 headers=oauth2_headers_user_1
@@ -279,7 +285,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             # Delete a file
             res = client.delete(
                 url_for(
-                    'invenio_deposit_rest.dep_file',
+                    'invenio_deposit_rest.depid_file',
                     pid_value=deposit_id,
                     key=file_data['filename']
                 ),
@@ -290,7 +296,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             # Get list of files
             res = client.get(
                 url_for(
-                    'invenio_deposit_rest.dep_files',
+                    'invenio_deposit_rest.depid_files',
                     pid_value=deposit_id
                 ),
                 headers=oauth2_headers_user_1
@@ -301,7 +307,7 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Rename file
             res = client.put(
-                url_for('invenio_deposit_rest.dep_file',
+                url_for('invenio_deposit_rest.depid_file',
                         pid_value=deposit_id,
                         key=file_data2['filename']),
                 data=json.dumps({'filename': 'another_test.pdf'}),
@@ -318,7 +324,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             ]
             for test_case in test_cases:
                 res = client.put(
-                    url_for('invenio_deposit_rest.dep_file',
+                    url_for('invenio_deposit_rest.depid_file',
                             pid_value=deposit_id,
                             key=data_rename['filename']),
                     data=json.dumps(test_case),
@@ -331,7 +337,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             ]
             for test_case in test_cases:
                 res = client.put(
-                    url_for('invenio_deposit_rest.dep_file',
+                    url_for('invenio_deposit_rest.depid_file',
                             pid_value=deposit_id,
                             key=data_rename['filename']),
                     data=json.dumps(test_case),
@@ -343,7 +349,8 @@ def test_deposition_file_operations(app, db, es, location, users,
 
             # Delete resource again
             res = client.delete(
-                url_for('invenio_deposit_rest.dep_item', pid_value=deposit_id),
+                url_for('invenio_deposit_rest.depid_item',
+                        pid_value=deposit_id),
                 headers=oauth2_headers_user_1
             )
             assert res.status_code == 204
@@ -351,7 +358,7 @@ def test_deposition_file_operations(app, db, es, location, users,
             # No files any more
             res = client.get(
                 url_for(
-                    'invenio_deposit_rest.dep_files',
+                    'invenio_deposit_rest.depid_files',
                     pid_value=deposit_id
                 ),
                 headers=oauth2_headers_user_1
@@ -363,14 +370,15 @@ def test_simple_rest_flow(app, db, es, location, fake_schemas, users,
                           json_headers):
     """Test simple flow using REST API."""
     app.config['RECORDS_REST_ENDPOINTS']['recid'][
-        'read_permission_factory_imp'] = 'invenio_records_rest.utils:allow_all'
+        'read_permission_factory_imp'] = \
+        'invenio_records_rest.utils:allow_all'
     app.config['RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY'] = \
         'invenio_records_rest.utils:allow_all'
 
     with app.test_request_context():
         with app.test_client() as client:
             # try create deposit as anonymous user (failing)
-            res = client.post(url_for('invenio_deposit_rest.dep_list'),
+            res = client.post(url_for('invenio_deposit_rest.depid_list'),
                               data=json.dumps({}), headers=json_headers)
             assert res.status_code == 401
 
@@ -381,7 +389,7 @@ def test_simple_rest_flow(app, db, es, location, fake_schemas, users,
             ))
 
             # try create deposit as logged in user
-            res = client.post(url_for('invenio_deposit_rest.dep_list'),
+            res = client.post(url_for('invenio_deposit_rest.depid_list'),
                               data=json.dumps({}), headers=json_headers)
             assert res.status_code == 201
 

--- a/tests/test_views_rest_files.py
+++ b/tests/test_views_rest_files.py
@@ -58,7 +58,7 @@ def test_files_get(app, db, deposit, files, users):
         with app.test_client() as client:
             # get resources without login
             res = client.get(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']))
             assert res.status_code == 401
             # login
@@ -68,7 +68,7 @@ def test_files_get(app, db, deposit, files, users):
             ))
             # get resources
             res = client.get(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 headers=[('Content-Type', 'application/json'),
                          ('Accept', 'application/json')]
@@ -88,7 +88,7 @@ def test_files_get(app, db, deposit, files, users):
             ))
             # get resources
             res = client.get(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']))
             assert res.status_code == 403
 
@@ -100,7 +100,7 @@ def test_files_get_oauth2(app, db, deposit, users, write_token_user_1,
         with app.test_client() as client:
             # get resources
             res = client.get(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 headers=oauth2_headers_user_1
             )
@@ -123,7 +123,7 @@ def test_files_get_without_files(app, db, deposit, users):
             ))
             # get resources
             res = client.get(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']))
             assert res.status_code == 200
             data = json.loads(res.data.decode('utf-8'))
@@ -141,7 +141,7 @@ def test_files_post_oauth2(app, db, deposit, files, users, write_token_user_1):
             # get resources
             file_to_upload = (BytesIO(content), filename)
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data={'file': file_to_upload, 'name': real_filename},
                 content_type='multipart/form-data',
@@ -167,7 +167,7 @@ def test_files_post(app, db, deposit, users):
             # test post without login
             file_to_upload = (BytesIO(content), filename)
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data={'file': file_to_upload, 'name': real_filename},
                 content_type='multipart/form-data'
@@ -180,7 +180,7 @@ def test_files_post(app, db, deposit, users):
             ))
             # test empty post
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data={'name': real_filename},
                 content_type='multipart/form-data'
@@ -189,7 +189,7 @@ def test_files_post(app, db, deposit, users):
             # test post
             file_to_upload = (BytesIO(content), filename)
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data={'file': file_to_upload, 'name': real_filename},
                 content_type='multipart/form-data'
@@ -217,7 +217,7 @@ def test_files_post(app, db, deposit, users):
             # test post
             file_to_upload = (BytesIO(content), filename)
             res = client.post(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data={'file': file_to_upload, 'name': real_filename},
                 content_type='multipart/form-data'
@@ -244,7 +244,7 @@ def test_files_put_oauth2(app, db, deposit, files, users, write_token_user_1):
             file_ids = [f.file_id for f in deposit.files]
             # order files
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data=json.dumps([
                     {'id': str(file_ids[1])},
@@ -288,7 +288,7 @@ def test_files_put(app, db, deposit, files, users):
             assert len(deposit['_files']) == 2
             # add new file (without login)
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data=json.dumps([
                     {'id': str(file_ids[1])},
@@ -303,7 +303,7 @@ def test_files_put(app, db, deposit, files, users):
             ))
             # order files
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data=json.dumps([
                     {'id': str(file_ids[1])},
@@ -333,7 +333,7 @@ def test_files_put(app, db, deposit, files, users):
             order = [f.key for f in deposit.files]
             # test files post
             res = client.put(
-                url_for('invenio_deposit_rest.dep_files',
+                url_for('invenio_deposit_rest.depid_files',
                         pid_value=deposit['_deposit']['id']),
                 data=json.dumps([
                     {'id': str(file_ids[1])},
@@ -354,7 +354,7 @@ def test_file_get(app, db, deposit, files, users):
         with app.test_client() as client:
             # get resource without login
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -366,7 +366,7 @@ def test_file_get(app, db, deposit, files, users):
             ))
             # get resource
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -386,7 +386,7 @@ def test_file_get(app, db, deposit, files, users):
             ))
             # get resource
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -404,7 +404,7 @@ def test_file_get_not_found(app, db, deposit, users):
             ))
             # get resource
             res = client.get(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key='not_found'
             ))
@@ -420,7 +420,7 @@ def test_file_delete_oauth2(app, db, deposit, files, users,
             # delete resource
             res = client.delete(
                 url_for(
-                    'invenio_deposit_rest.dep_file',
+                    'invenio_deposit_rest.depid_file',
                     pid_value=deposit['_deposit']['id'],
                     key=files[0].key
                 ),
@@ -442,7 +442,7 @@ def test_file_delete(app, db, deposit, files, users):
         with app.test_client() as client:
             deposit_id = deposit.id
             res = client.delete(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -458,7 +458,7 @@ def test_file_delete(app, db, deposit, files, users):
             ))
             # delete resource
             res = client.delete(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -477,7 +477,7 @@ def test_file_delete(app, db, deposit, files, users):
             ))
             # delete resource
             res = client.delete(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key=files[0].key
             ))
@@ -494,7 +494,7 @@ def test_file_put_not_found_bucket_not_exist(app, db, deposit, users):
                 password="tester"
             ))
             res = client.put(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key='not_found'),
                 data=json.dumps({'filename': 'foobar'})
@@ -512,7 +512,7 @@ def test_file_put_not_found_file_not_exist(app, db, deposit, files, users):
                 password="tester"
             ))
             res = client.put(url_for(
-                'invenio_deposit_rest.dep_file',
+                'invenio_deposit_rest.depid_file',
                 pid_value=deposit['_deposit']['id'],
                 key='not_found'),
                 data=json.dumps({'filename': 'foobar'})
@@ -529,7 +529,7 @@ def test_file_put_oauth2(app, db, deposit, files, users, write_token_user_1):
             new_filename = '{0}-new-name'.format(old_filename)
             # test rename file
             res = client.put(
-                url_for('invenio_deposit_rest.dep_file',
+                url_for('invenio_deposit_rest.depid_file',
                         pid_value=deposit['_deposit']['id'],
                         key=old_filename),
                 data=json.dumps({'filename': new_filename}),
@@ -561,7 +561,7 @@ def test_file_put(app, db, deposit, files, users):
             new_filename = '{0}-new-name'.format(old_filename)
             # test rename file (without login)
             res = client.put(
-                url_for('invenio_deposit_rest.dep_file',
+                url_for('invenio_deposit_rest.depid_file',
                         pid_value=deposit['_deposit']['id'],
                         key=old_filename),
                 data=json.dumps({'filename': new_filename}))
@@ -573,7 +573,7 @@ def test_file_put(app, db, deposit, files, users):
             ))
             # test rename file
             res = client.put(
-                url_for('invenio_deposit_rest.dep_file',
+                url_for('invenio_deposit_rest.depid_file',
                         pid_value=deposit['_deposit']['id'],
                         key=old_filename),
                 data=json.dumps({'filename': new_filename}))


### PR DESCRIPTION
* Changes the default `pid_type` to `depid`. (closes #44)

* Removes unused imports.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>