### PR TITLE
global: Deposit and Record subclass use allowed

### DIFF
--- a/invenio_deposit/proxies.py
+++ b/invenio_deposit/proxies.py
@@ -1,0 +1,34 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Helper proxy to the state object."""
+
+from __future__ import absolute_import, print_function
+
+from flask import current_app
+from werkzeug.local import LocalProxy
+
+current_deposit = LocalProxy(
+    lambda: current_app.extensions['invenio-deposit']
+)
+"""Helper proxy to access state object."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,9 +27,9 @@
 from __future__ import absolute_import, print_function
 
 import pytest
-from invenio_jsonschemas.errors import JSONSchemaNotFound
 from invenio_pidstore.errors import PIDInvalidAction
 from invenio_records.errors import MissingModelError
+from jsonschema.exceptions import RefResolutionError
 from six import BytesIO
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -51,7 +51,7 @@ def test_schemas(app, db, fake_schemas):
             '$schema': 'http://localhost/schemas/test-v1.0.0.json',
         })
 
-    with pytest.raises(JSONSchemaNotFound):
+    with pytest.raises(RefResolutionError):
         Deposit.create({
             '$schema': 'http://localhost/schemas/deposits/invalid.json',
         })

--- a/tests/test_invenio_deposit.py
+++ b/tests/test_invenio_deposit.py
@@ -27,11 +27,13 @@
 
 from __future__ import absolute_import, print_function
 
+import pytest
 from flask import Flask
 from flask_cli import FlaskCLI
 from invenio_records_rest.utils import PIDConverter
 
 from invenio_deposit import InvenioDeposit
+from invenio_deposit.proxies import current_deposit
 
 
 def test_version():
@@ -51,7 +53,17 @@ def test_init():
     app = Flask('testapp')
     FlaskCLI(app)
     app.url_map.converters['pid'] = PIDConverter
+
+    # check that current_deposit cannot be resolved
+    with app.app_context():
+        with pytest.raises(KeyError):
+            current_deposit.init_app
+
     ext = InvenioDeposit()
     assert 'invenio-deposit' not in app.extensions
     ext.init_app(app)
     assert 'invenio-deposit' in app.extensions
+
+    # check that current_deposit resolves correctly
+    with app.app_context():
+        current_deposit.init_app


### PR DESCRIPTION
* NEW Adds support for Deposit and Record API subclasses. (closes #77)

* NEW Enables the use of JSON Schemas from other sources than
  invenio-jsonschema.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>