### PR TITLE
views: local proxy fix

### DIFF
--- a/invenio_deposit/views/rest.py
+++ b/invenio_deposit/views/rest.py
@@ -297,7 +297,7 @@ class DepositFileResource(ContentNegotiatedMethodView):
     def get(self, pid, record, key, version_id, **kwargs):
         """Get deposit/depositions/:id/files/:key."""
         try:
-            obj = record.files[key].get_version(version_id=version_id)
+            obj = record.files[str(key)].get_version(version_id=version_id)
             return self.make_response(obj=obj or abort(404))
         except KeyError:
             abort(404)
@@ -313,11 +313,11 @@ class DepositFileResource(ContentNegotiatedMethodView):
             new_key = data['filename']
         except KeyError:
             raise WrongFile()
-        new_key = secure_filename(new_key)
-        if not new_key:
+        new_key_secure = secure_filename(new_key)
+        if not new_key_secure or new_key != new_key_secure:
             raise WrongFile()
         try:
-            obj = record.files.rename(key, new_key)
+            obj = record.files.rename(str(key), new_key_secure)
         except KeyError:
             abort(404)
         record.commit()
@@ -331,7 +331,7 @@ class DepositFileResource(ContentNegotiatedMethodView):
     def delete(self, pid, record, key):
         """Handle DELETE deposit files."""
         try:
-            del record.files[key]
+            del record.files[str(key)]
             record.commit()
             db.session.commit()
             return make_response('', 204)

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -370,18 +370,6 @@ def test_deposition_file_operations(app, db, es, location, users,
             # Bad renaming
             test_cases = [
                 dict(name="another_test.pdf"),
-            ]
-            for test_case in test_cases:
-                res = client.put(
-                    url_for('invenio_deposit_rest.depid_file',
-                            pid_value=deposit_id,
-                            key=data_rename['filename']),
-                    data=json.dumps(test_case),
-                    headers=oauth2_headers_user_1
-                )
-                assert res.status_code == 400
-
-            test_cases = [
                 dict(filename="../../etc/passwd"),
             ]
             for test_case in test_cases:
@@ -392,9 +380,7 @@ def test_deposition_file_operations(app, db, es, location, users,
                     data=json.dumps(test_case),
                     headers=oauth2_headers_user_1
                 )
-                assert res.status_code == 200
-                data_secured = json.loads(res.data.decode('utf-8'))
-                assert data_secured['filename'] == 'etc_passwd'
+                assert res.status_code == 400
 
             # Delete resource again
             res = client.delete(


### PR DESCRIPTION
* Fixes issue with key possibly being a LocalProxy causing SQLAlchemy
  to throw errors when the key is used in queries.

* Forces filenames to always be equivalent to their secure version.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>