### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Deposit.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-deposit
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_deposit/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_deposit/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     keywords='invenio deposit upload',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-deposit',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,9 +125,9 @@ def users(app):
     """Create users."""
     with db_.session.begin_nested():
         datastore = app.extensions['security'].datastore
-        user1 = datastore.create_user(email='info@invenio-software.org',
+        user1 = datastore.create_user(email='info@inveniosoftware.org',
                                       password='tester', active=True)
-        user2 = datastore.create_user(email='test@invenio-software.org',
+        user2 = datastore.create_user(email='test@inveniosoftware.org',
                                       password='tester2', active=True)
     db_.session.commit()
     return [user1, user2]

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -89,9 +89,9 @@ def test_publish_merge_conflict(app, db, es, users, location, deposit,
     # anonymous user
     (None, 401),
     # owner
-    (dict(email='info@invenio-software.org', password='tester'), 200),
+    (dict(email='info@inveniosoftware.org', password='tester'), 200),
     # user that not have permissions
-    (dict(email='test@invenio-software.org', password='tester2'), 403),
+    (dict(email='test@inveniosoftware.org', password='tester2'), 403),
 ])
 def test_edit_deposit_users(app, db, es, users, location, deposit,
                             json_headers, user_info, status):
@@ -149,9 +149,9 @@ def test_edit_deposit_by_bad_oauth2_token(app, db, es, users, location,
     # anonymous user
     (None, 401),
     # owner
-    (dict(email='info@invenio-software.org', password='tester'), 204),
+    (dict(email='info@inveniosoftware.org', password='tester'), 204),
     # user that not have permissions
-    (dict(email='test@invenio-software.org', password='tester2'), 403),
+    (dict(email='test@inveniosoftware.org', password='tester2'), 403),
 ])
 def test_delete_deposit_users(app, db, es, users, location, deposit,
                               json_headers, user_info, status):


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>