### PR TITLE
global: default_endpoint_prefixes init order fix

### DIFF
--- a/invenio_deposit/ext.py
+++ b/invenio_deposit/ext.py
@@ -132,8 +132,11 @@ class InvenioDepositREST(object):
             app.config['DEPOSIT_REST_ENDPOINTS']
         )
 
-        @blueprint.record_once
-        def extend_default_endpoint_prefixes(_):
+        # FIXME: This is a temporary fix. This means that
+        # invenio-records-rest's endpoint_prefixes cannot be used before
+        # the first request or in other processes, ex: Celery tasks.
+        @app.before_first_request
+        def extend_default_endpoint_prefixes():
             """Extend redirects between PID types."""
             endpoint_prefixes = utils.build_default_endpoint_prefixes(
                 dict(app.config['DEPOSIT_REST_ENDPOINTS'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,6 @@ def base_app(request):
             OAUTHLIB_INSECURE_TRANSPORT=True,
             OAUTH2_CACHE_TYPE='simple',
         )
-        app_.url_map.converters['pid'] = PIDConverter
         Babel(app_)
         FlaskCeleryExt(app_)
         Breadcrumbs(app_)
@@ -125,20 +124,25 @@ def base_app(request):
         InvenioSearch(app_)
 
     api_app = Flask('testapiapp', instance_path=instance_path)
+    api_app.url_map.converters['pid'] = PIDConverter
+    # initialize InvenioDeposit first in order to detect any invalid dependency
+    InvenioDepositREST(api_app)
+
     init_app(api_app)
     InvenioREST(api_app)
     InvenioOAuth2ServerREST(api_app)
     InvenioRecordsREST(api_app)
-    InvenioDepositREST(api_app)
 
     app = Flask('testapp', instance_path=instance_path)
+    app.url_map.converters['pid'] = PIDConverter
+    # initialize InvenioDeposit first in order to detect any invalid dependency
+    InvenioDeposit(app)
     init_app(app)
     app.register_blueprint(accounts_blueprint)
     app.register_blueprint(oauth2server_settings_blueprint)
     InvenioAssets(app)
     InvenioSearchUI(app)
     InvenioRecordsUI(app)
-    InvenioDeposit(app)
     app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
         '/api': api_app.wsgi_app
     })

--- a/tests/test_invenio_deposit.py
+++ b/tests/test_invenio_deposit.py
@@ -110,11 +110,10 @@ def test_conflict_in_endpoint_prefixes():
     deposit_endpoints = deepcopy(app.config['DEPOSIT_REST_ENDPOINTS'])
     deposit_endpoints['recid'] = endpoints['recid']
     app.config['DEPOSIT_REST_ENDPOINTS'] = deposit_endpoints
+    ext.init_app(app)
 
-    # check endpoint profixes
-    with pytest.raises(RuntimeError) as err:
-        ext.init_app(app)
-    assert 'recid' in str(err)
+    with app.test_client() as c:
+        assert 500 == c.get('/').status_code
 
 
 def test_template(base_app):


### PR DESCRIPTION
* FIX Fixes ext dependency on invenio-records-rest loading order
  by updating default_endpoint_prefixes on first request.
  (addresses #150)

* Fixes tests by setting a default
  RECORDS_UI_DEFAULT_PERMISSION_FACTORY.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>