### PR TITLE
deposit: index record after publish

### DIFF
--- a/invenio_deposit/api.py
+++ b/invenio_deposit/api.py
@@ -338,11 +338,15 @@ class Deposit(Record):
         self['_deposit']['status'] = 'published'
 
         if self['_deposit'].get('pid') is None:  # First publishing
-            self._publish_new(id_=id_)
+            record = self._publish_new(id_=id_)
         else:  # Update after edit
             record = self._publish_edited()
             record.commit()
         self.commit()
+
+        if current_app.config['DEPOSIT_RECORD_INDEX_ON_NEW_PUBLISH']:
+            self.indexer.index(record)
+
         return self
 
     def _prepare_edit(self, record):

--- a/invenio_deposit/config.py
+++ b/invenio_deposit/config.py
@@ -222,3 +222,6 @@ DEPOSIT_FORM_TEMPLATES = {
 
 DEPOSIT_RESPONSE_MESSAGES = {}
 """Alerts shown when actions are completed on deposit."""
+
+DEPOSIT_RECORD_INDEX_ON_NEW_PUBLISH = True
+"""Index a record when the deposit is published."""

--- a/invenio_deposit/ext.py
+++ b/invenio_deposit/ext.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 from collections import defaultdict
 
+from invenio_indexer.api import RecordIndexer
 from invenio_records_rest import utils
 from werkzeug.utils import cached_property
 
@@ -67,6 +68,12 @@ class _DepositState(object):
         return defaultdict(
             lambda: self.app.config['DEPOSIT_DEFAULT_SCHEMAFORM'], _schemaforms
         )
+
+    @cached_property
+    def indexer(self):
+        """Load indexer."""
+        if self.app.config['DEPOSIT_RECORD_INDEX_ON_NEW_PUBLISH']:
+            return RecordIndexer()
 
 
 class InvenioDeposit(object):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.5.1',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
  * Adds indexing a record after publishing, along with test.
    (closes #141)

Signed-off-by: PaulinaLach paulina.malgorzata.lach@cern.ch