### PR TITLE
global: fix [docutils 0.13.1] error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.4.2',
+        'Sphinx>=1.5.1',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
* Fixes issue with Sphinx caused by [docutils 0.13.1] assertion error.
  (closes #156)

Signed-off-by: PaulinaLach paulina.malgorzata.lach@cern.ch