### PR TITLE
deposit: signal publishing a record

### DIFF
--- a/invenio_deposit/signals.py
+++ b/invenio_deposit/signals.py
@@ -50,3 +50,9 @@ Example subscriber:
     from invenio_deposit.signals import post_action
     post_action.connect(listener)
 """
+
+before_record_publish = _signals.signal('before-record-publish')
+"""Signal is sent before a record is published."""
+
+after_record_publish = _signals.signal('after-record-publish')
+"""Signal sent after a record is published."""


### PR DESCRIPTION
* Adds sending signals before and after publishing a record, along with test.
  (addresses #141)

Signed-off-by: PaulinaLach paulina.malgorzata.lach@cern.ch