### PR TITLE
examples: fix deposit creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ target/
 # Examples
 examples/instance/
 examples/*.db
-examples/static/node_modules/
+examples/static
 examples/data/upload/*
 
 # temporary db

--- a/examples/app-fixtures.sh
+++ b/examples/app-fixtures.sh
@@ -15,5 +15,5 @@ export FLASK_APP=app.py
 flask users create info@inveniosoftware.org -a --password 123456
 
 # Load fixtures
+flask files location default /tmp --default
 flask fixtures records
-flask fixtures location

--- a/examples/app.py
+++ b/examples/app.py
@@ -30,6 +30,8 @@ Installation proccess
 
 Make sure that ``ElasticSearch`` and ``RabbitMQ`` servers are running.
 
+Note: make sure to install the mapper-attachments plugin for ElasticSearch.
+
 Run the demo:
 
 .. code-block:: console
@@ -71,6 +73,7 @@ from invenio_assets import InvenioAssets
 from invenio_db import InvenioDB, db
 from invenio_files_rest import InvenioFilesREST
 from invenio_files_rest.models import Location
+from invenio_files_rest.views import blueprint as files_rest_blueprint
 from invenio_i18n import InvenioI18N
 from invenio_indexer import InvenioIndexer
 from invenio_indexer.api import RecordIndexer
@@ -104,7 +107,7 @@ app.config.update(
     REST_ENABLE_CORS=True,
     SECRET_KEY='changeme',
     SQLALCHEMY_TRACK_MODIFICATIONS=True,
-    DEPOSIT_SEARCH_API='/deposits',
+    DEPOSIT_SEARCH_API='/deposits/',
     RECORDS_REST_FACETS=dict(
         deposits=dict(
             aggs=dict(
@@ -122,11 +125,12 @@ app.config.update(
     RECORDS_UI_DEFAULT_PERMISSION_FACTORY=None,
     SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
                                       'sqlite:///app.db'),
-    SEARCH_UI_SEARCH_API='/deposits',
+    SEARCH_UI_SEARCH_API='/deposits/',
     SEARCH_UI_JSTEMPLATE_RESULTS='templates/app/deposit.html',
     DATADIR=join(dirname(__file__), 'data/upload'),
     OAUTH2SERVER_CACHE_TYPE='simple',
     OAUTHLIB_INSECURE_TRANSPORT=True,
+    ACCOUNTS_JWT_ENABLE=False,
 )
 
 Babel(app)
@@ -170,6 +174,8 @@ app.register_blueprint(accounts_blueprint)
 
 app.register_blueprint(settings_blueprint)
 app.register_blueprint(server_blueprint)
+
+app.register_blueprint(files_rest_blueprint)
 
 
 @app.cli.group()

--- a/invenio_deposit/api.py
+++ b/invenio_deposit/api.py
@@ -243,7 +243,10 @@ class Deposit(Record):
 
             data['_deposit']['created_by'] = creator_id
 
-        return super(Deposit, cls).create(data, id_=id_)
+        deposit = super(Deposit, cls).create(data, id_=id_)
+        # FIXME create the bucket!
+        deposit.files.bucket
+        return deposit
 
     @contextmanager
     def _process_files(self, record_id, data):

--- a/invenio_deposit/config.py
+++ b/invenio_deposit/config.py
@@ -30,13 +30,13 @@ from invenio_records_rest.utils import check_elasticsearch
 from .utils import check_oauth2_scope_write, \
     check_oauth2_scope_write_elasticsearch
 
-DEPOSIT_SEARCH_API = '/api/deposits'
+DEPOSIT_SEARCH_API = '/api/deposits/'
 """URL of search endpoint for deposits."""
 
 DEPOSIT_RECORDS_API = '/api/deposits/{pid_value}'
 """URL of record endpoint for deposits."""
 
-DEPOSIT_FILES_API = '/api/files'
+DEPOSIT_FILES_API = '/api/files/'
 """URL of files endpoints for uploading."""
 
 DEPOSIT_PID_MINTER = 'recid'

--- a/invenio_deposit/links.py
+++ b/invenio_deposit/links.py
@@ -24,12 +24,24 @@
 
 """Links for record serialization."""
 
-from flask import current_app, has_request_context, request, url_for
+from flask import current_app, request, url_for
 from invenio_records_rest.links import default_links_factory
 from invenio_records_rest.proxies import current_records_rest
 
 from .api import Deposit
 from .utils import extract_actions_from_class
+
+
+def _bucket_link_factory(pid):
+    """Add the bucket link."""
+    try:
+        record = Deposit.get_record(pid.get_assigned_object())
+        bucket = record.files.bucket
+
+        return url_for('invenio_files_rest.bucket_api',
+                       bucket_id=bucket.id, _external=True)
+    except AttributeError:
+        return None
 
 
 def deposit_links_factory(pid):
@@ -62,6 +74,10 @@ def deposit_links_factory(pid):
                        **kwargs)
 
     links['files'] = _url('files')
+
+    bucket_link = _bucket_link_factory(pid)
+    if bucket_link is not None:
+        links['bucket'] = bucket_link
 
     ui_endpoint = current_app.config.get('DEPOSIT_UI_ENDPOINT')
     if ui_endpoint is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ from invenio_assets import InvenioAssets
 from invenio_db import InvenioDB, db
 from invenio_files_rest import InvenioFilesREST
 from invenio_files_rest.models import Location
+from invenio_files_rest.views import blueprint as files_rest_blueprint
 from invenio_indexer import InvenioIndexer
 from invenio_jsonschemas import InvenioJSONSchemas
 from invenio_oauth2server import InvenioOAuth2Server, InvenioOAuth2ServerREST
@@ -107,6 +108,7 @@ def base_app(request):
             SECURITY_DEPRECATED_PASSWORD_SCHEMES=[],
             OAUTHLIB_INSECURE_TRANSPORT=True,
             OAUTH2_CACHE_TYPE='simple',
+            ACCOUNTS_JWT_ENABLE=False,
         )
         Babel(app_)
         FlaskCeleryExt(app_)
@@ -118,10 +120,10 @@ def base_app(request):
         InvenioIndexer(app_)
         InvenioJSONSchemas(app_)
         InvenioOAuth2Server(app_)
-        InvenioFilesREST(app_)
         InvenioPIDStore(app_)
         InvenioRecords(app_)
         InvenioSearch(app_)
+        InvenioFilesREST(app_)
 
     api_app = Flask('testapiapp', instance_path=instance_path)
     api_app.url_map.converters['pid'] = PIDConverter
@@ -132,6 +134,8 @@ def base_app(request):
     InvenioREST(api_app)
     InvenioOAuth2ServerREST(api_app)
     InvenioRecordsREST(api_app)
+
+    api_app.register_blueprint(files_rest_blueprint)
 
     app = Flask('testapp', instance_path=instance_path)
     app.url_map.converters['pid'] = PIDConverter

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,7 +40,7 @@ from invenio_deposit.api import Deposit
 from invenio_deposit.errors import MergeConflict
 
 
-def test_schemas(app, fake_schemas):
+def test_schemas(app, fake_schemas, location, es):
     """Test schema URL transformations."""
     deposit = Deposit.create({})
     assert 'http://localhost/schemas/deposits/deposit-v1.0.0.json' == \

--- a/tests/test_views_rest_files.py
+++ b/tests/test_views_rest_files.py
@@ -37,7 +37,7 @@ from six import BytesIO
 from invenio_deposit.api import Deposit
 
 
-def test_created_by_population(api, users):
+def test_created_by_population(api, users, location, es):
     """Test created_by gets populated correctly."""
     record = {
         'title': 'fuu'


### PR DESCRIPTION
* Registers invenio-files-rest endpoints on example app.

* Fixes url for creating the deposit, avoiding the HTTP redirection.

* Disables JWT check on example app.

* Adds bucket link on response after deposit creation.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>