### PR TITLE
docs: point intersphinx to Flask 0.12

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2018 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -335,7 +335,7 @@ nitpick_ignore = [('py:class', 'Record'),
 intersphinx_mapping = {
     'https://docs.python.org/': None,
     'Flask': (
-        'http://flask.pocoo.org/docs/0.11', None
+        'http://flask.pocoo.org/docs/0.12', None
     ),
     'Flask-Principal': (
         # NOTE readthedocs version is currently broken


### PR DESCRIPTION
* Flask 0.11 documentation is gone, using Flask 0.12 instead.
  (see inveniosoftware/invenio-rest#90)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>